### PR TITLE
Update GCCPATH to 'gcc-arm-none-eabi-10-2020-q4-major-linux'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ endif
 ifneq ($(BOLOS_ENV),)
 $(info BOLOS_ENV=$(BOLOS_ENV))
 CLANGPATH := $(BOLOS_ENV)/clang-arm-fropi/bin/
-GCCPATH   := $(BOLOS_ENV)/gcc-arm-none-eabi-5_3-2016q1/bin/
+GCCPATH   := $(BOLOS_ENV)/gcc-arm-none-eabi-10-2020-q4-major-linux/bin/
 else
 $(info BOLOS_ENV is not set: falling back to CLANGPATH and GCCPATH)
 endif


### PR DESCRIPTION
Fix for `nanos-secure-sdk-2.0.0-1/src/cx_stubs.S:1:0: error: target CPU does not support ARM mode` error, by updating GCCPATH to the same version that is stated in [`Setting up the toolchain`](https://ledger.readthedocs.io/en/latest/userspace/setup.html#setting-up-the-toolchain).