### PR TITLE
Fix nanox dev env gcc path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,11 @@ endif
 ifneq ($(BOLOS_ENV),)
 $(info BOLOS_ENV=$(BOLOS_ENV))
 CLANGPATH := $(BOLOS_ENV)/clang-arm-fropi/bin/
+ifeq ($(TARGET_NAME),TARGET_NANOX)
+GCCPATH   := $(BOLOS_ENV)/gcc-arm-none-eabi-10-2020-q4-major/bin/
+else
 GCCPATH   := $(BOLOS_ENV)/gcc-arm-none-eabi-5_3-2016q1/bin/
+endif
 else
 $(info BOLOS_ENV is not set: falling back to CLANGPATH and GCCPATH)
 endif


### PR DESCRIPTION
Hello,
This PR fixes the GCCPATH for nanox when using the script from https://developers.ledger.com/docs/nano-app/quickstart/ so that it works out of the box.