### PR TITLE
Small fixes for I/O

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -14,11 +14,6 @@
 extern uint8_t G_io_seproxyhal_spi_buffer[IO_SEPROXYHAL_BUFFER_SIZE_B];
 
 /**
- * Global variable with the lenght of APDU response to send back.
- */
-extern uint32_t G_output_len;
-
-/**
  * Global structure to perform asynchronous UX aside IO operations.
  */
 extern ux_state_t G_ux;
@@ -27,11 +22,6 @@ extern ux_state_t G_ux;
  * Global structure with the parameters to exchange with the BOLOS UX application.
  */
 extern bolos_ux_params_t G_ux_params;
-
-/**
- * Global enumeration with the state of IO (READY, RECEIVING, WAITING).
- */
-extern io_state_e G_io_state;
 
 /**
  * Global context for user requests.

--- a/src/io.c
+++ b/src/io.c
@@ -26,8 +26,6 @@
 #include "common/buffer.h"
 #include "common/write.h"
 
-uint32_t G_output_len = 0;
-
 void io_seproxyhal_display(const bagl_element_t *element) {
     io_seproxyhal_display_default((bagl_element_t *) element);
 }
@@ -83,6 +81,22 @@ uint16_t io_exchange_al(uint8_t channel, uint16_t tx_len) {
     }
 
     return 0;
+}
+
+/**
+ * Variable containing the length of the APDU response to send back.
+ */
+static uint32_t G_output_len = 0;
+
+/**
+ * IO state (READY, RECEIVING, WAITING).
+ */
+static io_state_e G_io_state = READY;
+
+void io_init() {
+    // Reset length of APDU response
+    G_output_len = 0;
+    G_io_state = READY;
 }
 
 int io_recv_command() {

--- a/src/io.c
+++ b/src/io.c
@@ -100,7 +100,7 @@ void io_init() {
 }
 
 int io_recv_command() {
-    int ret;
+    int ret = -1;
 
     switch (G_io_state) {
         case READY:
@@ -122,7 +122,7 @@ int io_recv_command() {
 }
 
 int io_send_response(const buffer_t *rdata, uint16_t sw) {
-    int ret;
+    int ret = -1;
 
     if (rdata != NULL) {
         if (rdata->size - rdata->offset > IO_APDU_BUFFER_SIZE - 2 ||  //

--- a/src/io.h
+++ b/src/io.h
@@ -22,7 +22,14 @@ uint8_t io_event(uint8_t channel __attribute__((unused)));
 uint16_t io_exchange_al(uint8_t channel, uint16_t tx_len);
 
 /**
- * Receive APDU command in G_io_apdu_buffer and update G_output_len.
+ * Initialize the APDU I/O state.
+ *
+ * This function must be called before calling any other I/O function.
+ */
+void io_init(void);
+
+/**
+ * Receive APDU command in G_io_apdu_buffer.
  *
  * @return zero or positive integer if success, -1 otherwise.
  *

--- a/src/main.c
+++ b/src/main.c
@@ -30,7 +30,6 @@
 #include "apdu/dispatcher.h"
 
 uint8_t G_io_seproxyhal_spi_buffer[IO_SEPROXYHAL_BUFFER_SIZE_B];
-io_state_e G_io_state;
 ux_state_t G_ux;
 bolos_ux_params_t G_ux_params;
 global_ctx_t G_context;
@@ -44,9 +43,7 @@ void app_main() {
     // Structured APDU command
     command_t cmd;
 
-    // Reset length of APDU response
-    G_output_len = 0;
-    G_io_state = READY;
+    io_init();
 
     // Reset context
     explicit_bzero(&G_context, sizeof(G_context));


### PR DESCRIPTION
`G_output_len` and `G_io_state` were used only by `io.c` (except for initialization). There was no rationale to define them as global variables. Their visibility has been reduced to `io.c`.

Also, the return value of I/O functions have been initialized to fix defects (false positives?) identified by CodeQL.