### PR TITLE
Fix crypto exceptions

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -28,6 +28,7 @@ int crypto_derive_private_key(cx_ecfp_private_key_t *private_key,
                               const uint32_t *bip32_path,
                               uint8_t bip32_path_len) {
     uint8_t raw_private_key[32] = {0};
+    int error = 0;
 
     BEGIN_TRY {
         TRY {
@@ -44,7 +45,7 @@ int crypto_derive_private_key(cx_ecfp_private_key_t *private_key,
                                      private_key);
         }
         CATCH_OTHER(e) {
-            THROW(e);
+            error = e;
         }
         FINALLY {
             explicit_bzero(&raw_private_key, sizeof(raw_private_key));
@@ -52,7 +53,7 @@ int crypto_derive_private_key(cx_ecfp_private_key_t *private_key,
     }
     END_TRY;
 
-    return 0;
+    return error;
 }
 
 int crypto_init_public_key(cx_ecfp_private_key_t *private_key,
@@ -66,17 +67,20 @@ int crypto_init_public_key(cx_ecfp_private_key_t *private_key,
     return 0;
 }
 
-int crypto_sign_message() {
+int crypto_sign_message(void) {
     cx_ecfp_private_key_t private_key = {0};
     uint8_t chain_code[32] = {0};
     uint32_t info = 0;
     int sig_len = 0;
 
     // derive private key according to BIP32 path
-    crypto_derive_private_key(&private_key,
-                              chain_code,
-                              G_context.bip32_path,
-                              G_context.bip32_path_len);
+    int error = crypto_derive_private_key(&private_key,
+                                          chain_code,
+                                          G_context.bip32_path,
+                                          G_context.bip32_path_len);
+    if (error != 0) {
+        return error;
+    }
 
     BEGIN_TRY {
         TRY {
@@ -91,7 +95,7 @@ int crypto_sign_message() {
             PRINTF("Signature: %.*H\n", sig_len, G_context.tx_info.signature);
         }
         CATCH_OTHER(e) {
-            THROW(e);
+            error = e;
         }
         FINALLY {
             explicit_bzero(&private_key, sizeof(private_key));
@@ -99,12 +103,10 @@ int crypto_sign_message() {
     }
     END_TRY;
 
-    if (sig_len < 0) {
-        return -1;
+    if (error == 0) {
+        G_context.tx_info.signature_len = sig_len;
+        G_context.tx_info.v = (uint8_t)(info & CX_ECCINFO_PARITY_ODD);
     }
 
-    G_context.tx_info.signature_len = sig_len;
-    G_context.tx_info.v = (uint8_t)(info & CX_ECCINFO_PARITY_ODD);
-
-    return 0;
+    return error;
 }

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -56,15 +56,13 @@ int crypto_derive_private_key(cx_ecfp_private_key_t *private_key,
     return error;
 }
 
-int crypto_init_public_key(cx_ecfp_private_key_t *private_key,
-                           cx_ecfp_public_key_t *public_key,
-                           uint8_t raw_public_key[static 64]) {
+void crypto_init_public_key(cx_ecfp_private_key_t *private_key,
+                            cx_ecfp_public_key_t *public_key,
+                            uint8_t raw_public_key[static 64]) {
     // generate corresponding public key
     cx_ecfp_generate_pair(CX_CURVE_256K1, public_key, private_key, 1);
 
     memmove(raw_public_key, public_key->W + 1, 64);
-
-    return 0;
 }
 
 int crypto_sign_message(void) {

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -36,14 +36,12 @@ int crypto_derive_private_key(cx_ecfp_private_key_t *private_key,
  * @param[out] raw_public_key
  *   Pointer to raw public key.
  *
- * @return 0 if success, -1 otherwise.
- *
  * @throw INVALID_PARAMETER
  *
  */
-int crypto_init_public_key(cx_ecfp_private_key_t *private_key,
-                           cx_ecfp_public_key_t *public_key,
-                           uint8_t raw_public_key[static 64]);
+void crypto_init_public_key(cx_ecfp_private_key_t *private_key,
+                            cx_ecfp_public_key_t *public_key,
+                            uint8_t raw_public_key[static 64]);
 
 /**
  * Sign message hash in global context.

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -18,9 +18,7 @@
  * @param[in]  bip32_path_len
  *   Number of path in BIP32 path.
  *
- * @return 0 if success, -1 otherwise.
- *
- * @throw INVALID_PARAMETER
+ * @return 0 on success, error number otherwise.
  *
  */
 int crypto_derive_private_key(cx_ecfp_private_key_t *private_key,
@@ -53,9 +51,7 @@ int crypto_init_public_key(cx_ecfp_private_key_t *private_key,
  * @see G_context.bip32_path, G_context.tx_info.m_hash,
  * G_context.tx_info.signature.
  *
- * @return 0 if success, -1 otherwise.
- *
- * @throw INVALID_PARAMETER
+ * @return 0 on success, error number otherwise.
  *
  */
 int crypto_sign_message(void);

--- a/src/handler/get_public_key.c
+++ b/src/handler/get_public_key.c
@@ -47,10 +47,13 @@ int handler_get_public_key(buffer_t *cdata, bool display) {
     }
 
     // derive private key according to BIP32 path
-    crypto_derive_private_key(&private_key,
-                              G_context.pk_info.chain_code,
-                              G_context.bip32_path,
-                              G_context.bip32_path_len);
+    int error = crypto_derive_private_key(&private_key,
+                                          G_context.pk_info.chain_code,
+                                          G_context.bip32_path,
+                                          G_context.bip32_path_len);
+    if (error != 0) {
+        return io_send_sw(error);
+    }
     // generate corresponding public key
     crypto_init_public_key(&private_key, &public_key, G_context.pk_info.raw_public_key);
     // reset private key

--- a/src/ui/action/validate.c
+++ b/src/ui/action/validate.c
@@ -39,7 +39,7 @@ void ui_action_validate_transaction(bool choice) {
     if (choice) {
         G_context.state = STATE_APPROVED;
 
-        if (crypto_sign_message() < 0) {
+        if (crypto_sign_message() != 0) {
             G_context.state = STATE_NONE;
             io_send_sw(SW_SIGNATURE_FAIL);
         } else {


### PR DESCRIPTION
Crypto functions used to throw exceptions while they also return an error. It isn't consistent to mix these 2 behaviors. Let these functions just return an error.