### PR TITLE
Makefile: Drop BOLOS_ENV and let the SDK define build optimisation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,25 +84,9 @@ else
         DEFINES += PRINTF\(...\)=
 endif
 
-ifneq ($(BOLOS_ENV),)
-$(info BOLOS_ENV=$(BOLOS_ENV))
-CLANGPATH := $(BOLOS_ENV)/clang-arm-fropi/bin/
-GCCPATH   := $(BOLOS_ENV)/gcc-arm-none-eabi-5_3-2016q1/bin/
-else
-$(info BOLOS_ENV is not set: falling back to CLANGPATH and GCCPATH)
-endif
-ifeq ($(CLANGPATH),)
-$(info CLANGPATH is not set: clang will be used from PATH)
-endif
-ifeq ($(GCCPATH),)
-$(info GCCPATH is not set: arm-none-eabi-* will be used from PATH)
-endif
-
 CC      := $(CLANGPATH)clang
-CFLAGS  += -O3 -Os
 AS      := $(GCCPATH)arm-none-eabi-gcc
 LD      := $(GCCPATH)arm-none-eabi-gcc
-LDFLAGS += -O3 -Os
 LDLIBS  += -lm -lgcc -lc
 
 include $(BOLOS_SDK)/Makefile.glyphs


### PR DESCRIPTION
`BOLOS_ENV` is stuck at `gcc-arm-none-eabi-5_3-2016q1`. So probably not used anymore by anyone.
And optimization levels are already set by the SDK.

We can't remove CC, AS and LD definition as the SDK doesn't set them properly.