### PR TITLE
src: app_main.c: Stop catching throw in app_main()

### DIFF
--- a/src/app_main.c
+++ b/src/app_main.c
@@ -47,49 +47,32 @@ void app_main() {
     explicit_bzero(&G_context, sizeof(G_context));
 
     for (;;) {
-        BEGIN_TRY {
-            TRY {
-                // Reset structured APDU command
-                memset(&cmd, 0, sizeof(cmd));
+        // Receive command bytes in G_io_apdu_buffer
+        if ((input_len = io_recv_command()) < 0) {
+            PRINTF("=> io_recv_command failure\n");
+            return;
+        }
 
-                // Receive command bytes in G_io_apdu_buffer
-                if ((input_len = io_recv_command()) < 0) {
-                    CLOSE_TRY;
-                    return;
-                }
+        // Parse APDU command from G_io_apdu_buffer
+        if (!apdu_parser(&cmd, G_io_apdu_buffer, input_len)) {
+            PRINTF("=> /!\\ BAD LENGTH: %.*H\n", input_len, G_io_apdu_buffer);
+            io_send_sw(SW_WRONG_DATA_LENGTH);
+            continue;
+        }
 
-                // Parse APDU command from G_io_apdu_buffer
-                if (!apdu_parser(&cmd, G_io_apdu_buffer, input_len)) {
-                    PRINTF("=> /!\\ BAD LENGTH: %.*H\n", input_len, G_io_apdu_buffer);
-                    io_send_sw(SW_WRONG_DATA_LENGTH);
-                    CLOSE_TRY;
-                    continue;
-                }
+        PRINTF("=> CLA=%02X | INS=%02X | P1=%02X | P2=%02X | Lc=%02X | CData=%.*H\n",
+               cmd.cla,
+               cmd.ins,
+               cmd.p1,
+               cmd.p2,
+               cmd.lc,
+               cmd.lc,
+               cmd.data);
 
-                PRINTF("=> CLA=%02X | INS=%02X | P1=%02X | P2=%02X | Lc=%02X | CData=%.*H\n",
-                       cmd.cla,
-                       cmd.ins,
-                       cmd.p1,
-                       cmd.p2,
-                       cmd.lc,
-                       cmd.lc,
-                       cmd.data);
-
-                // Dispatch structured APDU command to handler
-                if (apdu_dispatcher(&cmd) < 0) {
-                    CLOSE_TRY;
-                    return;
-                }
-            }
-            CATCH(EXCEPTION_IO_RESET) {
-                THROW(EXCEPTION_IO_RESET);
-            }
-            CATCH_OTHER(e) {
-                io_send_sw(e);
-            }
-            FINALLY {
-            }
-            END_TRY;
+        // Dispatch structured APDU command to handler
+        if (apdu_dispatcher(&cmd) < 0) {
+            PRINTF("=> apdu_dispatcher failure\n");
+            return;
         }
     }
 }


### PR DESCRIPTION
The app used to throw errors in "nominal" situation, including user deny of a request or even user approval. This was at that time seen as an efficient way to answer the APDU while not having to forward the error code.

This was a tricky mecanism, relying on an even trickier TRY/CATCH mecanism which brings many potentials issues.

Now, errors can be throwned only from the OS/SDK and in non nominal situation. So it is safe to stop catching theses errors here, which allowed to send a response to APDU, and let them be catch in the main() function which is in SDK standard_app library.

Linked to https://github.com/LedgerHQ/ledger-secure-sdk/pull/354