### PR TITLE
Add ledger-dev-tools in extensions.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
 	"recommendations": [
         "ms-vscode.cpptools",
+        "LedgerHQ.ledger-dev-tools",
 	]
 }


### PR DESCRIPTION
For some reasons, this important extension is missing from the reco :)

Here it is now:

<img width="583" alt="image" src="https://github.com/LedgerHQ/app-boilerplate/assets/477945/f2fbf6ce-58e3-4c2d-8a29-336e0c6a98fd">
