### PR TITLE
Remove duplicate entry from the .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,6 @@ SortIncludes: false
 SpaceAfterCStyleCast: true
 AllowShortCaseLabelsOnASingleLine: false
 AllowAllArgumentsOnNextLine: false
-AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: Never
 AllowShortFunctionsOnASingleLine: None
 BinPackArguments: false


### PR DESCRIPTION
Removed duplicated `AllowAllParametersOfDeclarationOnNextLine`

Closes #138 