### PR TITLE
Migrate tests to ledgered 'Devices' per Ragger v1.35.0

### DIFF
--- a/tests/setup.cfg
+++ b/tests/setup.cfg
@@ -21,3 +21,6 @@ ignore_missing_imports = True
 
 [mypy-pytest.*]
 ignore_missing_imports = True
+
+[mypy-ledgered.*]
+ignore_missing_imports = True

--- a/tests/test_app_mainmenu.py
+++ b/tests/test_app_mainmenu.py
@@ -1,15 +1,15 @@
-from ragger.firmware import Firmware
+from ledgered.devices import Device, DeviceType
 from ragger.navigator import Navigator, NavInsID, NavIns
 
 
 # In this test we check the behavior of the device main menu
-def test_app_mainmenu(firmware: Firmware,
+def test_app_mainmenu(device: Device,
                       navigator: Navigator,
                       test_name: str,
                       default_screenshot_path: str) -> None:
     # Navigate in the main menu
     instructions = []
-    if firmware.is_nano:
+    if device.is_nano:
         instructions += [
             NavInsID.RIGHT_CLICK,
             NavInsID.BOTH_CLICK,
@@ -28,7 +28,7 @@ def test_app_mainmenu(firmware: Firmware,
             NavInsID.BOTH_CLICK,
             NavInsID.RIGHT_CLICK,
         ]
-    elif firmware is Firmware.STAX:
+    elif device.type == DeviceType.STAX:
         instructions += [
             NavInsID.USE_CASE_HOME_SETTINGS,
             NavIns(NavInsID.TOUCH, (200, 113)),
@@ -38,7 +38,7 @@ def test_app_mainmenu(firmware: Firmware,
             NavInsID.USE_CASE_SETTINGS_NEXT,
             NavInsID.USE_CASE_SETTINGS_MULTI_PAGE_EXIT
         ]
-    elif firmware is Firmware.FLEX:
+    elif device.type is DeviceType.FLEX:
         instructions += [
             NavInsID.USE_CASE_HOME_SETTINGS,
             NavIns(NavInsID.TOUCH, (200, 113)),


### PR DESCRIPTION
# Checklist

<!-- Put an `x` in each box when you have completed the items. -->

- [ ] App update process has been followed <!-- See comment below -->
- [ ] Target branch is `develop` <!-- unless you have a very good reason -->
- [ ] Application version has been bumped <!-- required if your changes are to be deployed -->


## Summary 
As of Ragger v1.35.0 `firmware.structs` were removed. Ragger uses `ledgered` Devices instead of local `Firmware` / `FIRMWARES`. This PR updates the tests to use the `ledgered.Device` and `ledgered.DeviceType` library. In addition, the config file `setup.cfg` adds `ignore missing imports` for the newly added library. 

## Note
- Target `master` Did not see a `develop` branch. 
- Other PRs did not bump version so no version bump here. 
